### PR TITLE
Updates to pass some `String` values by reference

### DIFF
--- a/src/ConfigJson.h
+++ b/src/ConfigJson.h
@@ -53,7 +53,7 @@ public:
   bool set(const char *name, int val) {
     return set<int>(name, val);
   } 
-  bool set(const char *name, String val) {
+  bool set(const char *name, String &val) {
     return set<String>(name, val);
   } 
   bool set(const char *name, bool val) {
@@ -62,19 +62,19 @@ public:
   bool set(const char *name, double val) {
     return set<double>(name, val);
   } 
-  bool set(String name, uint32_t val) {
+  bool set(String &name, uint32_t val) {
     return set<uint32_t>(name.c_str(), val);
   } 
-  bool set(String name, int val) {
+  bool set(String &name, int val) {
     return set<int>(name.c_str(), val);
   } 
-  bool set(String name, String val) {
+  bool set(String &name, String &val) {
     return set<String>(name.c_str(), val);
   } 
-  bool set(String name, bool val) {
+  bool set(String &name, bool val) {
     return set<bool>(name.c_str(), val);
   } 
-  bool set(String name, double val) {
+  bool set(String &name, double val) {
     return set<double>(name.c_str(), val);
   } 
 

--- a/src/ConfigOptDefinition.h
+++ b/src/ConfigOptDefinition.h
@@ -24,7 +24,7 @@ public:
     return _val;
   }
 
-  virtual bool set(T value) {    
+  virtual bool set(T &value) {    
     if(_val != value) {
       _val = value;
       return true;

--- a/src/ConfigOptSecret.h
+++ b/src/ConfigOptSecret.h
@@ -17,7 +17,7 @@ public:
   {
   }
 
-  bool set(String value) {
+  bool set(String &value) {
     if(value.equals(DUMMY_PASSWORD)) {
       return false;
     }


### PR DESCRIPTION
Should help performance by avoiding memory copies

Fixes #3 